### PR TITLE
Add dist standard library

### DIFF
--- a/compiler/lib/dist.ods
+++ b/compiler/lib/dist.ods
@@ -1,0 +1,16 @@
+/*
+ * COMS4115: ODDS Dist Standard Library
+ *
+ * Authors:
+ *  - Alex Kalicki
+ *  - Alexandra Medway
+ *  - Daniel Echikson
+ *  - Lilly Wang
+ */
+
+ do uniform = (x) -> return 1
+
+ do normal = (x) ->
+    do coef = 1 / (2 * PI) ** 0.5
+    do exp = -1 * x ** 2 / 2
+    return coef * EUL ** exp

--- a/compiler/lib/list.ods
+++ b/compiler/lib/list.ods
@@ -1,5 +1,5 @@
 /*
- * COMS4115: ODDS Standard Library
+ * COMS4115: ODDS List Standard Library
  *
  * Authors:
  *  - Alex Kalicki

--- a/odds.sh
+++ b/odds.sh
@@ -2,7 +2,8 @@
 
 MYDIR="$(dirname "$(which "$0")")"
 ODDS_FILE="$MYDIR/compiler/odds"
-ODDS_LIB="$MYDIR/compiler/lib/lib.ods"
+LIST_LIB="$MYDIR/compiler/lib/list.ods"
+DIST_LIB="$MYDIR/compiler/lib/dist.ods"
 PY_LIB="$MYDIR/compiler/lib/core.py"
 
 if [ ! -f $ODDS_FILE ]; then
@@ -13,7 +14,7 @@ fi
 # odds.sh (-c | -r) <odds_file> <output_file>
 if [ "$#" -eq 3 ]; then
     if [ "$1" == "-c" ]; then
-        cat $ODDS_LIB $2 | $ODDS_FILE $1 $3 $PY_LIB
+        cat $LIST_LIB $DIST_LIB $2 | $ODDS_FILE $1 $3 $PY_LIB
         exit 0
     elif [ "$1" == "-r" ]; then
         $ODDS_FILE $1 $3 < $2


### PR DESCRIPTION
Let me know if we need any more dist standard library functions. We'll need to add support for PI and EUL constants (@lillyfwang #82) before this can be merged in.

cc @odds-lang/dev for review