### PR TITLE
Fixed 4 bugs in Analyzer

### DIFF
--- a/test/compiler/fail/_rec_return_change.out
+++ b/test/compiler/fail/_rec_return_change.out
@@ -1,1 +1,2 @@
-Analyzer Exception: Invalid attempt to reassign function identifier 'f' to type Num
+Analyzer Exception: Invalid return type in function 'f':
+    type 'Bool' expected to be returned, but type 'Num' returned instead.


### PR DESCRIPTION
### Fixes:
1. Improper error was being called on function return type mismatch
2. Fixed `constrain_ew` constrain error checks - though we never ran into any issues w/ these, the way we were doing it (`old_type <> Unconst`) might have thrown an error if we tried to constrain a `List(Unconst`) to a `List(const)`.
3. MOST IMPORTANT: any function that returns a `List(Any)` will, upon invocation, return a `List(Unconst)` - before, we were returning a `List(Any)` which could have led to some serious issues down the line. The only reason we were not having issues before is actually because of the bug in `constrain_ew` (see __fix 2__), which was allowing us to constrain `List(Any)` to `List(Num)` or any other `List(const)`.
4. Fixed bug in `check_fdecl` where an error (an improper error, see __fix 1__) was being thrown if return type was `List(Any)`.