### PR TITLE
Removed uniform

### DIFF
--- a/compiler/parser.mly
+++ b/compiler/parser.mly
@@ -126,12 +126,6 @@ dist:
       max = $4;
       dist_func = $6;
     } }
-  | LCAR expr COMMA expr RCAR
-    { {
-      min = $2;
-      max = $4;
-      dist_func = Ast.Id("uniform");
-    } }
 
 discr_dist:
   | DISC expr COMMA expr DDELIM 


### PR DESCRIPTION
They now need to specify a function. Honestly, why did we choose uniform anyway. If we wanted to give a default function i feel like normal is better. Or it's not! Now we dont have to worry