### PR TITLE
Report correct line on error

### DIFF
--- a/compiler/odds.ml
+++ b/compiler/odds.ml
@@ -57,9 +57,7 @@ let _ =
           "\x1b[31mSyntax error\x1b[0m, line %d at column %d: %s\n" 
           line_num column_num m 
     | Analyzer.Semantic_Error(m) -> 
-        let line_num, _, _ = get_pos_and_tok lexbuf in
-        eprintf "\x1b[31mSemantic error\x1b[0m, line %d:\n  %s\n" 
-          line_num m
+        eprintf "\x1b[31mSemantic error\x1b[0m:\n  %s\n" m
     | Parsing.Parse_error -> 
         let line_num, column_num, token = get_pos_and_tok lexbuf in
         eprintf 

--- a/compiler/scanner.mll
+++ b/compiler/scanner.mll
@@ -15,11 +15,15 @@
 
 let numeric = ['0'-'9']
 let whitespace = [' ' '\n' '\r' '\t']
+let newline = '\n' | "\r\n"
 
 rule token = parse
 
+(* Newline - for line number on error report to user *)
+| newline   { Lexing.new_line lexbuf; token lexbuf }
+
 (* Whitespace *)
-| whitespace*    { token lexbuf }
+| whitespace    { token lexbuf }
 
 (* Comments *)
 | "/*"    { comment lexbuf }
@@ -89,4 +93,5 @@ rule token = parse
 
 and comment = parse
 | "*/"    { token lexbuf }
+| newline { Lexing.new_line lexbuf; comment lexbuf }
 | _       { comment lexbuf }

--- a/test/compiler/fail/_binop_logical.out
+++ b/test/compiler/fail/_binop_logical.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid use of binary operator '&&' with types Bool and Num

--- a/test/compiler/fail/_binop_numeric.out
+++ b/test/compiler/fail/_binop_numeric.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid use of binary operator '<=' with types Num and Bool

--- a/test/compiler/fail/_call_func_param_num.out
+++ b/test/compiler/fail/_call_func_param_num.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Function 'call' expected argument of type Func(Any => Bool) but was passed Func( => Bool) instead

--- a/test/compiler/fail/_call_length.out
+++ b/test/compiler/fail/_call_length.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Function 'sum' expects 2 argument(s) but was called with 3 instead

--- a/test/compiler/fail/_call_nonfunc.out
+++ b/test/compiler/fail/_call_nonfunc.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Attempting to call Num type 'f' as a function

--- a/test/compiler/fail/_call_types.out
+++ b/test/compiler/fail/_call_types.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Function 'sum' expected argument of type Num but was passed String instead

--- a/test/compiler/fail/_discr_dist.out
+++ b/test/compiler/fail/_discr_dist.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid distribution with vals type 'Num' and weights type 'List[Num]'

--- a/test/compiler/fail/_fdecl_anon.out
+++ b/test/compiler/fail/_fdecl_anon.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Function 'sum' expected argument of type Num but was passed Bool instead

--- a/test/compiler/fail/_fdecl_nested.out
+++ b/test/compiler/fail/_fdecl_nested.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Function 'sum' expected argument of type Num but was passed Bool instead

--- a/test/compiler/fail/_if_cond.out
+++ b/test/compiler/fail/_if_cond.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Expected type Bool but got type Num instead

--- a/test/compiler/fail/_if_mismatch.out
+++ b/test/compiler/fail/_if_mismatch.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid attempt to use conditional with mismatched types Num and String

--- a/test/compiler/fail/_illegal_char.ods
+++ b/test/compiler/fail/_illegal_char.ods
@@ -1,1 +1,2 @@
+do x = 42
 do illegal = ~

--- a/test/compiler/fail/_illegal_char.out
+++ b/test/compiler/fail/_illegal_char.out
@@ -1,1 +1,1 @@
-[31mSyntax error[0m, line 1 at column 14: illegal character '~'
+[31mSyntax error[0m, line 2 at column 14: illegal character '~'

--- a/test/compiler/fail/_list_head_types.out
+++ b/test/compiler/fail/_list_head_types.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid use of binary operator '||' with types Num and Bool

--- a/test/compiler/fail/_list_heterogeneous.out
+++ b/test/compiler/fail/_list_heterogeneous.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid element of type Bool in list of type List[String]

--- a/test/compiler/fail/_list_tail_types.out
+++ b/test/compiler/fail/_list_tail_types.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid use of binary operator '||' with types Num and Bool

--- a/test/compiler/fail/_print_return_type.out
+++ b/test/compiler/fail/_print_return_type.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid use of binary operator '+' with types String and Num

--- a/test/compiler/fail/_rec_param_change.out
+++ b/test/compiler/fail/_rec_param_change.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Function 'f' expected argument of type Num but was passed Bool instead

--- a/test/compiler/fail/_rec_return_change.out
+++ b/test/compiler/fail/_rec_return_change.out
@@ -1,3 +1,3 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid return type in function 'f':
     type 'Bool' expected to be returned, but type 'Num' returned instead.

--- a/test/compiler/fail/_unop_not.out
+++ b/test/compiler/fail/_unop_not.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid use of unary operator '!' with type Num

--- a/test/compiler/fail/_unop_sub.out
+++ b/test/compiler/fail/_unop_sub.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Invalid use of unary operator '-' with type Bool

--- a/test/compiler/fail/_var_scope.out
+++ b/test/compiler/fail/_var_scope.out
@@ -1,2 +1,2 @@
-[31mSemantic error[0m, line 1:
+[31mSemantic error[0m:
   Variable 'y' is undefined in current scope


### PR DESCRIPTION
1. Removed line num reporting on semantic errors
2. Parser errors and scanner errors now report correct line num (previously they were always reporting line 1)